### PR TITLE
fix "minetest.setting_* functions are deprecated" warning

### DIFF
--- a/armchairs.lua
+++ b/armchairs.lua
@@ -1,6 +1,6 @@
 local armchairs_list = {
 	{ "Red Armchair", "red"},
-	{ "Orange Armchair", "orange"},	
+	{ "Orange Armchair", "orange"},
 	{ "Yellow Armchair", "yellow"},
 	{ "Green Armchair", "green"},
 	{ "Blue Armchair", "blue"},
@@ -31,13 +31,13 @@ for i in ipairs(armchairs_list) do
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, 0.3125, 0.5, 0.5, 0.5},
-						
+
 						--arms
 						{-0.5, 0, -0.5, -0.3125, 0.25, 0.3125},
 						{0.3125, 0, -0.5, 0.5, 0.25, 0.3125},
@@ -59,7 +59,7 @@ for i in ipairs(armchairs_list) do
 			clicker:set_hp(20)
 		end
 	})
-	
+
 	minetest.register_craft({
 		output = "lrfurn:armchair_"..colour,
 		recipe = {
@@ -68,7 +68,7 @@ for i in ipairs(armchairs_list) do
 			{"default:stick", "", "", }
 		}
 	})
-	
+
 	minetest.register_craft({
 		output = "lrfurn:armchair_"..colour,
 		recipe = {
@@ -89,6 +89,6 @@ for i in ipairs(armchairs_list) do
 
 end
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "armchairs loaded")
 end

--- a/coffeetable.lua
+++ b/coffeetable.lua
@@ -13,9 +13,9 @@ minetest.register_node("lrfurn:coffeetable_back", {
 					--legs
 					{-0.375, -0.5, -0.375, -0.3125, -0.0625, -0.3125},
 					{0.3125, -0.5, -0.375, 0.375, -0.0625, -0.3125},
-					
+
 					--tabletop
-					{-0.4375, -0.0625, -0.4375, 0.4375, 0, 0.5},	
+					{-0.4375, -0.0625, -0.4375, 0.4375, 0, 0.5},
 				}
 	},
 	selection_box = {
@@ -42,7 +42,7 @@ minetest.register_node("lrfurn:coffeetable_back", {
 			minetest.env:set_node(pos, node)
 		end
 	end,
-		
+
 	on_destruct = function(pos)
 		local node = minetest.env:get_node(pos)
 		local param2 = node.param2
@@ -58,7 +58,7 @@ minetest.register_node("lrfurn:coffeetable_back", {
 		if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).name == "lrfurn:coffeetable_front" ) then
 			if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).param2 == param2 ) then
 				minetest.env:remove_node(pos)
-			end	
+			end
 		end
 	end,
 })
@@ -76,7 +76,7 @@ minetest.register_node("lrfurn:coffeetable_front", {
 					--legs
 					{-0.375, -0.5, 0.3125, -0.3125, -0.0625, 0.375},
 					{0.3125, -0.5, 0.3125, 0.375, -0.0625, 0.375},
-					
+
 					--tabletop
 					{-0.4375, -0.0625, -0.5, 0.4375, 0, 0.4375},
 				}
@@ -118,6 +118,6 @@ minetest.register_craft({
 	}
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "coffeetable loaded")
 end

--- a/endtable.lua
+++ b/endtable.lua
@@ -15,9 +15,9 @@ minetest.register_node("lrfurn:endtable", {
 					{0.3125, -0.5, -0.375, 0.375, -0.0625, -0.3125},
 					{-0.375, -0.5, 0.3125, -0.3125, -0.0625, 0.375},
 					{0.3125, -0.5, 0.3125, 0.375, -0.0625, 0.375},
-					
+
 					--tabletop
-					{-0.4375, -0.0625, -0.4375, 0.4375, 0, 0.4375},	
+					{-0.4375, -0.0625, -0.4375, 0.4375, 0, 0.4375},
 				}
 	},
 	selection_box = {
@@ -55,6 +55,6 @@ minetest.register_craft({
 	}
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "endtable loaded")
 end

--- a/longsofas.lua
+++ b/longsofas.lua
@@ -1,6 +1,6 @@
 local longsofas_list = {
 	{ "Red Long Sofa", "red"},
-	{ "Orange Long Sofa", "orange"},	
+	{ "Orange Long Sofa", "orange"},
 	{ "Yellow Long Sofa", "yellow"},
 	{ "Green Long Sofa", "green"},
 	{ "Blue Long Sofa", "blue"},
@@ -29,13 +29,13 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.4375, -0.375, -0.375, -0.375},
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, -0.5, 0.5, 0.25, -0.3125},
 					}
@@ -77,7 +77,7 @@ for i in ipairs(longsofas_list) do
 				end
 			end
 		end,
-			
+
 		on_destruct = function(pos)
 			local node = minetest.env:get_node(pos)
 			local param2 = node.param2
@@ -105,12 +105,12 @@ for i in ipairs(longsofas_list) do
 					if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).name == "lrfurn:longsofa_left_"..colour ) then
 						if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).param2 == param2 ) then
 							minetest.env:remove_node(pos)
-						end	
+						end
 					end
-				end	
+				end
 			end
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			if not clicker:is_player() then
 				return
@@ -134,10 +134,10 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.03125, -0.375, -0.375, 0.03125},
 						{0.375, -0.5, -0.03125, 0.4375, -0.375, 0.03125},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
 					}
@@ -149,7 +149,7 @@ for i in ipairs(longsofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_node("lrfurn:longsofa_left_"..colour, {
 		drawtype = "nodebox",
 		tiles = {"lrfurn_sofa_left_top_"..colour..".png", "lrfurn_coffeetable_back.png",  "lrfurn_sofa_left_front_"..colour..".png",  "lrfurn_sofa_back_"..colour..".png",  "lrfurn_sofa_left_side_"..colour..".png",  "lrfurn_sofa_right_side_"..colour..".png"},
@@ -163,13 +163,13 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, 0.3125, 0.5, 0.25, 0.5},
 					}
@@ -181,9 +181,9 @@ for i in ipairs(longsofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_alias("lrfurn:longsofa_"..colour, "lrfurn:longsofa_right_"..colour)
-	
+
 	minetest.register_craft({
 		output = "lrfurn:longsofa_"..colour,
 		recipe = {
@@ -213,6 +213,6 @@ for i in ipairs(longsofas_list) do
 
 end
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "long sofas loaded")
 end

--- a/sofas.lua
+++ b/sofas.lua
@@ -1,6 +1,6 @@
 local sofas_list = {
 	{ "Red Sofa", "red"},
-	{ "Orange Sofa", "orange"},	
+	{ "Orange Sofa", "orange"},
 	{ "Yellow Sofa", "yellow"},
 	{ "Green Sofa", "green"},
 	{ "Blue Sofa", "blue"},
@@ -29,13 +29,13 @@ for i in ipairs(sofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.4375, -0.375, -0.375, -0.375},
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, -0.5, 0.5, 0.25, -0.3125},
 					}
@@ -64,7 +64,7 @@ for i in ipairs(sofas_list) do
 				minetest.env:set_node(pos, node)
 			end
 		end,
-			
+
 		on_destruct = function(pos)
 			local node = minetest.env:get_node(pos)
 			local param2 = node.param2
@@ -80,10 +80,10 @@ for i in ipairs(sofas_list) do
 			if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).name == "lrfurn:sofa_left_"..colour ) then
 				if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).param2 == param2 ) then
 					minetest.env:remove_node(pos)
-				end	
+				end
 			end
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			if not clicker:is_player() then
 				return
@@ -93,7 +93,7 @@ for i in ipairs(sofas_list) do
 			clicker:set_hp(20)
 		end
 	})
-	
+
 	minetest.register_node("lrfurn:sofa_left_"..colour, {
 		drawtype = "nodebox",
 		tiles = {"lrfurn_sofa_left_top_"..colour..".png", "lrfurn_coffeetable_back.png",  "lrfurn_sofa_left_front_"..colour..".png",  "lrfurn_sofa_back_"..colour..".png",  "lrfurn_sofa_left_side_"..colour..".png",  "lrfurn_sofa_right_side_"..colour..".png"},
@@ -107,13 +107,13 @@ for i in ipairs(sofas_list) do
 						--legs
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, 0.3125, 0.5, 0.25, 0.5},
 					}
@@ -125,7 +125,7 @@ for i in ipairs(sofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_alias("lrfurn:sofa_"..colour, "lrfurn:sofa_right_"..colour)
 
 	minetest.register_craft({
@@ -157,6 +157,6 @@ for i in ipairs(sofas_list) do
 
 end
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "sofas loaded")
 end


### PR DESCRIPTION
This PR fixes these warning:
```
2021-04-24 12:34:07: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at /home/minetest-pvp/.minetest/mods/lrfurn/longsofas.lua:216)
2021-04-24 12:34:07: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at /home/minetest-pvp/.minetest/mods/lrfurn/sofas.lua:160)
2021-04-24 12:34:07: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at /home/minetest-pvp/.minetest/mods/lrfurn/armchairs.lua:92)
2021-04-24 12:34:07: WARNING[Main]: Not registering alias, item with same name is already defined: lrfurn:coffeetable -> lrfurn:coffeetable_back
2021-04-24 12:34:07: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at /home/minetest-pvp/.minetest/mods/lrfurn/coffeetable.lua:121)
2021-04-24 12:34:07: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at /home/minetest-pvp/.minetest/mods/lrfurn/endtable.lua:58)
```