### PR TITLE
fix setpos warning

### DIFF
--- a/armchairs.lua
+++ b/armchairs.lua
@@ -1,6 +1,6 @@
 local armchairs_list = {
 	{ "Red Armchair", "red"},
-	{ "Orange Armchair", "orange"},	
+	{ "Orange Armchair", "orange"},
 	{ "Yellow Armchair", "yellow"},
 	{ "Green Armchair", "green"},
 	{ "Blue Armchair", "blue"},
@@ -31,13 +31,13 @@ for i in ipairs(armchairs_list) do
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, 0.3125, 0.5, 0.5, 0.5},
-						
+
 						--arms
 						{-0.5, 0, -0.5, -0.3125, 0.25, 0.3125},
 						{0.3125, 0, -0.5, 0.5, 0.25, 0.3125},
@@ -55,11 +55,11 @@ for i in ipairs(armchairs_list) do
 				return
 			end
 			pos.y = pos.y-0.5
-			clicker:setpos(pos)
+			clicker:set_pos(pos)
 			clicker:set_hp(20)
 		end
 	})
-	
+
 	minetest.register_craft({
 		output = "lrfurn:armchair_"..colour,
 		recipe = {
@@ -68,7 +68,7 @@ for i in ipairs(armchairs_list) do
 			{"default:stick", "", "", }
 		}
 	})
-	
+
 	minetest.register_craft({
 		output = "lrfurn:armchair_"..colour,
 		recipe = {

--- a/longsofas.lua
+++ b/longsofas.lua
@@ -1,6 +1,6 @@
 local longsofas_list = {
 	{ "Red Long Sofa", "red"},
-	{ "Orange Long Sofa", "orange"},	
+	{ "Orange Long Sofa", "orange"},
 	{ "Yellow Long Sofa", "yellow"},
 	{ "Green Long Sofa", "green"},
 	{ "Blue Long Sofa", "blue"},
@@ -29,13 +29,13 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.4375, -0.375, -0.375, -0.375},
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, -0.5, 0.5, 0.25, -0.3125},
 					}
@@ -77,7 +77,7 @@ for i in ipairs(longsofas_list) do
 				end
 			end
 		end,
-			
+
 		on_destruct = function(pos)
 			local node = minetest.env:get_node(pos)
 			local param2 = node.param2
@@ -105,18 +105,18 @@ for i in ipairs(longsofas_list) do
 					if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).name == "lrfurn:longsofa_left_"..colour ) then
 						if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).param2 == param2 ) then
 							minetest.env:remove_node(pos)
-						end	
+						end
 					end
-				end	
+				end
 			end
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			if not clicker:is_player() then
 				return
 			end
 			pos.y = pos.y-0.5
-			clicker:setpos(pos)
+			clicker:set_pos(pos)
 			clicker:set_hp(20)
 		end
 	})
@@ -134,10 +134,10 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.03125, -0.375, -0.375, 0.03125},
 						{0.375, -0.5, -0.03125, 0.4375, -0.375, 0.03125},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
 					}
@@ -149,7 +149,7 @@ for i in ipairs(longsofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_node("lrfurn:longsofa_left_"..colour, {
 		drawtype = "nodebox",
 		tiles = {"lrfurn_sofa_left_top_"..colour..".png", "lrfurn_coffeetable_back.png",  "lrfurn_sofa_left_front_"..colour..".png",  "lrfurn_sofa_back_"..colour..".png",  "lrfurn_sofa_left_side_"..colour..".png",  "lrfurn_sofa_right_side_"..colour..".png"},
@@ -163,13 +163,13 @@ for i in ipairs(longsofas_list) do
 						--legs
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, 0.3125, 0.5, 0.25, 0.5},
 					}
@@ -181,9 +181,9 @@ for i in ipairs(longsofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_alias("lrfurn:longsofa_"..colour, "lrfurn:longsofa_right_"..colour)
-	
+
 	minetest.register_craft({
 		output = "lrfurn:longsofa_"..colour,
 		recipe = {

--- a/sofas.lua
+++ b/sofas.lua
@@ -1,6 +1,6 @@
 local sofas_list = {
 	{ "Red Sofa", "red"},
-	{ "Orange Sofa", "orange"},	
+	{ "Orange Sofa", "orange"},
 	{ "Yellow Sofa", "yellow"},
 	{ "Green Sofa", "green"},
 	{ "Blue Sofa", "blue"},
@@ -29,13 +29,13 @@ for i in ipairs(sofas_list) do
 						--legs
 						{-0.4375, -0.5, -0.4375, -0.375, -0.375, -0.375},
 						{0.375, -0.5, -0.4375, 0.4375, -0.375, -0.375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, -0.5, 0.5, 0.25, -0.3125},
 					}
@@ -64,7 +64,7 @@ for i in ipairs(sofas_list) do
 				minetest.env:set_node(pos, node)
 			end
 		end,
-			
+
 		on_destruct = function(pos)
 			local node = minetest.env:get_node(pos)
 			local param2 = node.param2
@@ -80,20 +80,20 @@ for i in ipairs(sofas_list) do
 			if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).name == "lrfurn:sofa_left_"..colour ) then
 				if( minetest.env:get_node({x=pos.x, y=pos.y, z=pos.z}).param2 == param2 ) then
 					minetest.env:remove_node(pos)
-				end	
+				end
 			end
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			if not clicker:is_player() then
 				return
 			end
 			pos.y = pos.y-0.5
-			clicker:setpos(pos)
+			clicker:set_pos(pos)
 			clicker:set_hp(20)
 		end
 	})
-	
+
 	minetest.register_node("lrfurn:sofa_left_"..colour, {
 		drawtype = "nodebox",
 		tiles = {"lrfurn_sofa_left_top_"..colour..".png", "lrfurn_coffeetable_back.png",  "lrfurn_sofa_left_front_"..colour..".png",  "lrfurn_sofa_back_"..colour..".png",  "lrfurn_sofa_left_side_"..colour..".png",  "lrfurn_sofa_right_side_"..colour..".png"},
@@ -107,13 +107,13 @@ for i in ipairs(sofas_list) do
 						--legs
 						{-0.4375, -0.5, 0.375, -0.375, -0.375, 0.4375},
 						{0.375, -0.5, 0.375, 0.4375, -0.375, 0.4375},
-						
+
 						--base/cushion
 						{-0.5, -0.375, -0.5, 0.5, 0, 0.5},
-						
+
 						--back
 						{-0.5, 0, -0.5, -0.3125, 0.5, 0.5},
-						
+
 						--arm
 						{-0.3125, 0, 0.3125, 0.5, 0.25, 0.5},
 					}
@@ -125,7 +125,7 @@ for i in ipairs(sofas_list) do
 					}
 		},
 	})
-	
+
 	minetest.register_alias("lrfurn:sofa_"..colour, "lrfurn:sofa_right_"..colour)
 
 	minetest.register_craft({


### PR DESCRIPTION
This PR fixes these warnings:
```
2021-04-24 08:13:57: WARNING[Server]: Call to deprecated function 'setpos', please use 'set_pos' at /home/minetest-pvp/.minetest/mods/lrfurn/longsofas.lua:119
2021-04-24 08:33:56: WARNING[Server]: Call to deprecated function 'setpos', please use 'set_pos' at /home/minetest-pvp/.minetest/mods/lrfurn/armchairs.lua:58
```